### PR TITLE
chore: rename package to @neovici/cosmoz-resizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @neovici/resizable
+# @neovici/cosmoz-resizable
 
 ## 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @neovici/resizable
+# @neovici/cosmoz-resizable
 
 A pionjs web component package for resizable split layouts.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@neovici/resizable",
-  "version": "1.0.0",
+  "name": "@neovici/cosmoz-resizable",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@neovici/resizable",
-      "version": "1.0.0",
+      "name": "@neovici/cosmoz-resizable",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pionjs/pion": "^2.16.1",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@neovici/resizable",
+  "name": "@neovici/cosmoz-resizable",
   "version": "1.1.0",
   "description": "A simple, lightweight web component for resizing two adjacent elements with a draggable divider line",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Neovici/resizable.git"
+    "url": "git+https://github.com/Neovici/cosmoz-resizable.git"
   },
   "keywords": [
     "web-components",


### PR DESCRIPTION
Refs FE-872

## Summary

- Rename npm package `@neovici/resizable` → `@neovici/cosmoz-resizable` to align with `@neovici/cosmoz-queue` naming pattern
- Fix `repository.url` in `package.json` — was pointing to non-existent `Neovici/resizable.git`, now correctly `Neovici/cosmoz-resizable.git`
- Update `README.md` and `CHANGELOG.md` headings to match

## npm changes

- Old `@neovici/resizable` unpublished from npm (both 1.0.0 and 1.1.0 — no downstream dependents)
- New `@neovici/cosmoz-resizable@1.1.0` published to npm

## Test plan

- [x] 61 tests passing (56 WTR + 5 vitest)
- [x] `npm run lint` clean (2 pre-existing `max-statements` warnings)
- [x] `npm run build` clean