### PR TITLE
fix: homepage URL pointing to non-existent Neovici/resizable

### DIFF
--- a/.changeset/fix-homepage-url.md
+++ b/.changeset/fix-homepage-url.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-resizable': patch
+---
+
+Fix `homepage` URL in `package.json` — was pointing to non-existent `Neovici/resizable`, now correctly `Neovici/cosmoz-resizable`.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/Neovici/resizable#readme",
+  "homepage": "https://github.com/Neovici/cosmoz-resizable#readme",
   "main": "dist/index.js",
   "type": "module",
   "directories": {


### PR DESCRIPTION
## Summary

Fix `homepage` field in `package.json` — was pointing to `https://github.com/Neovici/resizable#readme` (non-existent repo), now correctly `https://github.com/Neovici/cosmoz-resizable#readme`.

Follow-up to PR #5 which fixed `repository.url` but missed `homepage`.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean (2 pre-existing warnings)