### PR TITLE
chore: add changeset for css-driven flex rewrite

### DIFF
--- a/.changeset/css-driven-flex.md
+++ b/.changeset/css-driven-flex.md
@@ -1,0 +1,7 @@
+---
+'@neovici/cosmoz-resizable': major
+---
+
+Rewrite to CSS-driven flex model with rAF-batched drag.
+
+**Breaking:** Explicit `slot="previous"` and `slot="next"` required on slotted elements. Removed `initialSizes`, `minSize`, `useResizable`, `SizeSpec`, ratio support, `PersistAdapter` object form on `persist` prop.


### PR DESCRIPTION
Adds changeset for the major rewrite in #8. Bumps `@neovici/cosmoz-resizable` to 2.0.0.