### PR TITLE
feat: attribute-driven sizing API with direction-aware persistence

### DIFF
--- a/.changeset/feat-attribute-sizing.md
+++ b/.changeset/feat-attribute-sizing.md
@@ -1,0 +1,15 @@
+---
+'@neovici/cosmoz-resizable': minor
+---
+
+feat: attribute-driven sizing API with direction-aware persistence
+
+- `initial-size` / `min-size` attributes (+ `-horizontal` / `-vertical` variants) replace CSS var plumbing
+- Unitless values auto-appended with `px` (e.g. `min-size="200"` → `200px`); values with units or CSS functions pass through unchanged
+- Direction-prefixed persist key: `${persist}:${direction}` — separate stored size per direction
+- Persist stores actual rendered size via rAF + getBoundingClientRect instead of mouse position
+- Stale inline `flexBasis` cleared on direction change when no stored value for the new direction
+- `isVisible` checks `display` instead of bounding rect — prevents `data-single-panel` oscillation
+- `readBounds` simplified to min-only (flexbox enforces effective max via other panel's min)
+- `onResizeEnd` no longer receives `px` param
+- CSS custom properties (`--resizable-previous-*`, `--resizable-next-*`) are internal implementation detail

--- a/src/hooks/use-persist.ts
+++ b/src/hooks/use-persist.ts
@@ -102,7 +102,7 @@ export const localStorageAdapter = (
 export const usePersist = (
 	adapter: PersistAdapter | undefined,
 	key: string | undefined,
-	onRestore: (value: PersistedState) => void,
+	onRestore: (value: PersistedState | undefined) => void,
 ): ((value: PersistedState) => void) | undefined => {
 	const onRestoreRef = useRef(onRestore);
 	onRestoreRef.current = onRestore;
@@ -110,7 +110,7 @@ export const usePersist = (
 	useEffect(() => {
 		if (!adapter || !key) return;
 		const restored = adapter.get(key);
-		if (restored != null) onRestoreRef.current?.(restored);
+		onRestoreRef.current?.(restored);
 		const unsubscribe = adapter.subscribe?.(key, (v) =>
 			onRestoreRef.current?.(v),
 		);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { localStorageAdapter, usePersist } from './hooks/use-persist';
+export { parseSizeAttr } from './parse-size';
 export { ResizableView } from './resizable-view';
 export { ResizeHandle } from './resize-handle';
 export { createFlexResize } from './resizers';

--- a/src/parse-size.ts
+++ b/src/parse-size.ts
@@ -1,0 +1,17 @@
+const addUnit = (value: string): string => {
+	const trimmed = value.trim();
+	if (trimmed === '') return trimmed;
+	const n = Number(trimmed);
+	return Number.isNaN(n) ? trimmed : `${n}px`;
+};
+
+export const parseSizeAttr = (
+	raw: string | null,
+): { previous?: string; next?: string } => {
+	if (raw == null || raw.trim() === '') return {};
+	const parts = raw.includes(',') ? raw.split(/,\s*/u) : raw.split(/\s+/u);
+	return {
+		previous: addUnit(parts[0]),
+		next: parts.length > 1 ? addUnit(parts[1]) : undefined,
+	};
+};

--- a/src/resizable-view.css.ts
+++ b/src/resizable-view.css.ts
@@ -16,6 +16,7 @@ export const styles = css`
 	::slotted([slot='previous']) {
 		flex-grow: 0;
 		flex-shrink: 1;
+		flex-basis: var(--resizable-previous-basis, auto);
 		min-width: 0;
 		min-height: 0;
 		overflow: auto;
@@ -24,10 +25,35 @@ export const styles = css`
 	::slotted([slot='next']) {
 		flex-grow: 1;
 		flex-shrink: 1;
-		flex-basis: 0;
+		flex-basis: var(--resizable-next-basis, 0);
 		min-width: 0;
 		min-height: 0;
 		overflow: auto;
+	}
+
+	:host([data-direction='horizontal']) ::slotted([slot='previous']) {
+		min-width: var(
+			--resizable-previous-min-horizontal,
+			var(--resizable-previous-min, 0)
+		);
+	}
+	:host([data-direction='horizontal']) ::slotted([slot='next']) {
+		min-width: var(
+			--resizable-next-min-horizontal,
+			var(--resizable-next-min, 0)
+		);
+	}
+	:host([data-direction='vertical']) ::slotted([slot='previous']) {
+		min-height: var(
+			--resizable-previous-min-vertical,
+			var(--resizable-previous-min, 0)
+		);
+	}
+	:host([data-direction='vertical']) ::slotted([slot='next']) {
+		min-height: var(
+			--resizable-next-min-vertical,
+			var(--resizable-next-min, 0)
+		);
 	}
 
 	cosmoz-resize-handle {

--- a/src/resizable-view.ts
+++ b/src/resizable-view.ts
@@ -10,6 +10,7 @@ import {
 import { html } from 'lit-html';
 import { ref } from 'lit-html/directives/ref.js';
 import { localStorageAdapter, usePersist } from './hooks/use-persist';
+import { parseSizeAttr } from './parse-size';
 import { styles } from './resizable-view.css';
 import './resize-handle';
 import { createFlexResize } from './resizers';
@@ -18,12 +19,16 @@ import { PersistedState, ResizerDirection } from './types';
 interface ResizableViewProps {
 	direction?: ResizerDirection;
 	persist?: string;
+	initialSize?: string;
+	initialSizeHorizontal?: string;
+	initialSizeVertical?: string;
+	minSize?: string;
+	minSizeHorizontal?: string;
+	minSizeVertical?: string;
 }
 
-const isVisible = (el: HTMLElement): boolean => {
-	const { width, height } = el.getBoundingClientRect();
-	return width > 0 && height > 0;
-};
+const isVisible = (el: HTMLElement): boolean =>
+	getComputedStyle(el).display !== 'none';
 
 const slotted = (slot: HTMLSlotElement | undefined): HTMLElement | undefined =>
 	slot?.assignedElements()[0] as HTMLElement | undefined;
@@ -45,13 +50,49 @@ const observeVisibility = (
 };
 
 const restore = (previous: HTMLElement, state: PersistedState | undefined) => {
-	if (state == null) return;
+	if (state == null) {
+		previous.style.flexBasis = '';
+		return;
+	}
 	previous.style.flexBasis = `${state.px}px`;
+};
+
+const applySizeVars = (
+	host: HTMLElement,
+	varSuffix: string,
+	base?: string,
+	horizontal?: string,
+	vertical?: string,
+) => {
+	const set = (suffix: string, value?: string) => {
+		const { previous, next } = parseSizeAttr(value ?? null);
+		const prevProp = `--resizable-previous-${varSuffix}${suffix}`;
+		const nextProp = `--resizable-next-${varSuffix}${suffix}`;
+		if (previous != null) {
+			host.style.setProperty(prevProp, previous);
+		} else {
+			host.style.removeProperty(prevProp);
+		}
+		if (next != null) {
+			host.style.setProperty(nextProp, next);
+		} else {
+			host.style.removeProperty(nextProp);
+		}
+	};
+	set('', base);
+	set('-horizontal', horizontal);
+	set('-vertical', vertical);
 };
 
 const ResizableView = ({
 	direction = 'horizontal',
 	persist,
+	initialSize,
+	initialSizeHorizontal,
+	initialSizeVertical,
+	minSize,
+	minSizeHorizontal,
+	minSizeVertical,
 }: ResizableViewProps) => {
 	const host = useHost();
 	const handleRef = useRef<HTMLElement>();
@@ -59,16 +100,22 @@ const ResizableView = ({
 	const nextSlotRef = useRef<HTMLSlotElement>();
 	const [panelsReady, setPanelsReady] = useState(false);
 
+	const persistKey = persist ? `${persist}:${direction}` : undefined;
+
 	const adapter = useMemo(
 		() => (persist ? localStorageAdapter() : undefined),
 		[persist],
 	);
 
-	const persistState = usePersist(adapter, persist, (state: PersistedState) => {
-		const previous = slotted(prevSlotRef.current);
-		if (!previous) return;
-		restore(previous, state);
-	});
+	const persistState = usePersist(
+		adapter,
+		persistKey,
+		(state: PersistedState | undefined) => {
+			const previous = slotted(prevSlotRef.current);
+			if (!previous) return;
+			restore(previous, state);
+		},
+	);
 
 	const persistRef = useRef(persistState);
 	persistRef.current = persistState;
@@ -82,6 +129,25 @@ const ResizableView = ({
 	useEffect(() => {
 		host.setAttribute('data-direction', direction);
 	}, [direction]);
+
+	useEffect(() => {
+		applySizeVars(
+			host,
+			'basis',
+			initialSize,
+			initialSizeHorizontal,
+			initialSizeVertical,
+		);
+		applySizeVars(host, 'min', minSize, minSizeHorizontal, minSizeVertical);
+	}, [
+		host,
+		initialSize,
+		initialSizeHorizontal,
+		initialSizeVertical,
+		minSize,
+		minSizeHorizontal,
+		minSizeVertical,
+	]);
 
 	useEffect(() => {
 		if (!panelsReady) return;
@@ -98,8 +164,13 @@ const ResizableView = ({
 			onResize: (px) => {
 				previous.style.flexBasis = `${px}px`;
 			},
-			onResizeEnd: (px) => {
-				persistRef.current?.({ px });
+			onResizeEnd: () => {
+				requestAnimationFrame(() => {
+					const rect = previous.getBoundingClientRect();
+					const actualPx =
+						direction === 'horizontal' ? rect.width : rect.height;
+					persistRef.current?.({ px: actualPx });
+				});
 			},
 		});
 		handle.addEventListener('resize-handle', handler as EventListener);
@@ -128,7 +199,16 @@ customElements.define(
 	'cosmoz-resizable-view',
 	component(ResizableView, {
 		styleSheets: [styles],
-		observedAttributes: ['direction', 'persist'],
+		observedAttributes: [
+			'direction',
+			'persist',
+			'initial-size',
+			'initial-size-horizontal',
+			'initial-size-vertical',
+			'min-size',
+			'min-size-horizontal',
+			'min-size-vertical',
+		],
 	}),
 );
 

--- a/src/resizers.ts
+++ b/src/resizers.ts
@@ -30,18 +30,13 @@ const parsePx = (value: string): number | undefined => {
 const readBounds = (
 	el: HTMLElement,
 	direction: ResizerDirection,
-): { min: number; max: number } => {
+): { min: number } => {
 	const style = getComputedStyle(el);
-	if (direction === 'horizontal') {
-		return {
-			min: parsePx(style.minWidth) ?? 0,
-			max: parsePx(style.maxWidth) ?? Infinity,
-		};
-	}
-	return {
-		min: parsePx(style.minHeight) ?? 0,
-		max: parsePx(style.maxHeight) ?? Infinity,
-	};
+	const min =
+		direction === 'horizontal'
+			? (parsePx(style.minWidth) ?? 0)
+			: (parsePx(style.minHeight) ?? 0);
+	return { min };
 };
 
 const snapshot = (config: ResizeConfig) => {
@@ -53,39 +48,35 @@ const computePx = (
 	mousePosition: MousePosition,
 	rect: DOMRect,
 	direction: ResizerDirection,
-	bounds: { min: number; max: number },
-): number =>
-	Math.max(
-		bounds.min,
-		Math.min(axis(mousePosition, rect, direction), bounds.max),
-	);
+	bounds: { min: number },
+): number => Math.max(bounds.min, axis(mousePosition, rect, direction));
 
 export const createFlexResize = (config: ResizeConfig): ResizeHandler => {
-	let snap: { rect: DOMRect; bounds: { min: number; max: number } } | undefined;
+	let _snapshot: { rect: DOMRect; bounds: { min: number } } | undefined;
 
 	return (e) => {
 		const { phase, mousePosition } = e.detail;
 
 		if (phase === 'start') {
-			snap = snapshot(config);
+			_snapshot = snapshot(config);
 			return;
 		}
 
 		if (phase !== 'move' && phase !== 'end') return;
-		if (!snap) snap = snapshot(config);
+		if (!_snapshot) _snapshot = snapshot(config);
 
 		const px = computePx(
 			mousePosition,
-			snap.rect,
+			_snapshot.rect,
 			config.direction,
-			snap.bounds,
+			_snapshot.bounds,
 		);
 
 		if (phase === 'move') {
 			config.onResize?.(px);
 		} else {
-			config.onResizeEnd?.(px);
-			snap = undefined;
+			config.onResizeEnd?.();
+			_snapshot = undefined;
 		}
 	};
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,5 +29,5 @@ export interface ResizeConfig {
 	previous: HTMLElement;
 	direction: ResizerDirection;
 	onResize?: (px: number) => void;
-	onResizeEnd?: (px: number) => void;
+	onResizeEnd?: () => void;
 }

--- a/test/parse-size.test.js
+++ b/test/parse-size.test.js
@@ -1,0 +1,58 @@
+import { expect } from '@open-wc/testing';
+import { parseSizeAttr } from '../src/parse-size';
+
+describe('parseSizeAttr', () => {
+	it('parses whitespace-separated values', () => {
+		expect(parseSizeAttr('200 100')).to.deep.equal({
+			previous: '200px',
+			next: '100px',
+		});
+	});
+
+	it('parses comma-separated values', () => {
+		expect(parseSizeAttr('200, 100')).to.deep.equal({
+			previous: '200px',
+			next: '100px',
+		});
+	});
+
+	it('single value applies to previous only', () => {
+		expect(parseSizeAttr('200')).to.deep.equal({
+			previous: '200px',
+			next: undefined,
+		});
+	});
+
+	it('preserves percentage units', () => {
+		expect(parseSizeAttr('60%')).to.deep.equal({
+			previous: '60%',
+			next: undefined,
+		});
+	});
+
+	it('preserves calc() with internal spaces (comma-separated)', () => {
+		expect(parseSizeAttr('calc(100% - 200px), 300px')).to.deep.equal({
+			previous: 'calc(100% - 200px)',
+			next: '300px',
+		});
+	});
+
+	it('preserves other CSS units (em, rem, vw, vh)', () => {
+		expect(parseSizeAttr('2em 3rem')).to.deep.equal({
+			previous: '2em',
+			next: '3rem',
+		});
+	});
+
+	it('returns empty for null', () => {
+		expect(parseSizeAttr(null)).to.deep.equal({});
+	});
+
+	it('returns empty for empty string', () => {
+		expect(parseSizeAttr('')).to.deep.equal({});
+	});
+
+	it('returns empty for whitespace-only string', () => {
+		expect(parseSizeAttr('   ')).to.deep.equal({});
+	});
+});

--- a/test/resizable-view.test.js
+++ b/test/resizable-view.test.js
@@ -11,8 +11,9 @@ Object.defineProperty(window, 'onerror', {
 	},
 	set(v) {
 		_onerror = (msg, ...rest) => {
-			if (typeof msg === 'string' && msg.includes('ResizeObserver loop'))
-				{return true;}
+			if (typeof msg === 'string' && msg.includes('ResizeObserver loop')) {
+				return true;
+			}
 			return v?.(msg, ...rest);
 		};
 	},
@@ -153,7 +154,7 @@ describe('cosmoz-resizable-view', () => {
 
 	it('restores persisted px as flex-basis on mount', async () => {
 		localStorage.setItem(
-			'cosmoz-resizable-view:test-restore',
+			'cosmoz-resizable-view:test-restore:horizontal',
 			JSON.stringify({ px: 250 }),
 		);
 		const el = await fixture(
@@ -172,6 +173,161 @@ describe('cosmoz-resizable-view', () => {
 			{ timeout: 3000 },
 		);
 		expect(prev.style.flexBasis).to.equal('250px');
-		localStorage.removeItem('cosmoz-resizable-view:test-restore');
+		localStorage.removeItem('cosmoz-resizable-view:test-restore:horizontal');
+	});
+
+	it('clears stale flexBasis when no persisted value exists', async () => {
+		const el = await fixture(
+			html`<cosmoz-resizable-view
+				style="display:flex; width:600px; height:300px;"
+				persist="test-clear"
+				initial-size="60%"
+			>
+				<div id="prev" slot="previous" style="flex-basis: 999px">prev</div>
+				<div id="next" slot="next">next</div>
+			</cosmoz-resizable-view>`,
+		);
+		const prev = el.querySelector('#prev');
+		await waitUntil(
+			() => prev.style.flexBasis === '',
+			'flex-basis should be cleared when no stored value',
+			{ timeout: 3000 },
+		);
+		expect(prev.style.flexBasis).to.equal('');
+	});
+
+	it('clears stale flexBasis on direction change with no stored value', async () => {
+		localStorage.setItem(
+			'cosmoz-resizable-view:test-direction:horizontal',
+			JSON.stringify({ px: 300 }),
+		);
+		const el = await fixture(
+			html`<cosmoz-resizable-view
+				style="display:flex; width:600px; height:600px;"
+				persist="test-direction"
+				direction="horizontal"
+			>
+				<div id="prev" slot="previous">prev</div>
+				<div id="next" slot="next">next</div>
+			</cosmoz-resizable-view>`,
+		);
+		const prev = el.querySelector('#prev');
+		await waitUntil(
+			() => prev.style.flexBasis === '300px',
+			'horizontal flex-basis should be restored',
+			{ timeout: 3000 },
+		);
+		expect(prev.style.flexBasis).to.equal('300px');
+
+		el.setAttribute('direction', 'vertical');
+		await waitUntil(
+			() => prev.style.flexBasis === '',
+			'flex-basis should be cleared after direction change with no vertical stored value',
+			{ timeout: 3000 },
+		);
+		expect(prev.style.flexBasis).to.equal('');
+
+		localStorage.removeItem('cosmoz-resizable-view:test-direction:horizontal');
+	});
+
+	it('initial-size attribute sets flex-basis on previous', async () => {
+		const el = await fixture(
+			html`<cosmoz-resizable-view
+				style="display:flex; width:600px; height:300px;"
+				initial-size="60%"
+			>
+				<div id="prev" slot="previous">prev</div>
+				<div id="next" slot="next">next</div>
+			</cosmoz-resizable-view>`,
+		);
+		await waitUntil(
+			() => el.shadowRoot.querySelector('cosmoz-resize-handle'),
+			undefined,
+			{ timeout: 3000 },
+		);
+		const prev = el.querySelector('#prev');
+		expect(getComputedStyle(prev).flexBasis).to.equal('60%');
+	});
+
+	it('min-size attribute sets min-width in horizontal', async () => {
+		const el = await fixture(
+			html`<cosmoz-resizable-view
+				style="display:flex; width:600px; height:300px;"
+				min-size="200 100"
+			>
+				<div id="prev" slot="previous">prev</div>
+				<div id="next" slot="next">next</div>
+			</cosmoz-resizable-view>`,
+		);
+		await waitUntil(
+			() => el.shadowRoot.querySelector('cosmoz-resize-handle'),
+			undefined,
+			{ timeout: 3000 },
+		);
+		const prev = el.querySelector('#prev');
+		const next = el.querySelector('#next');
+		expect(getComputedStyle(prev).minWidth).to.equal('200px');
+		expect(getComputedStyle(next).minWidth).to.equal('100px');
+	});
+
+	it('single-value min-size applies to previous only', async () => {
+		const el = await fixture(
+			html`<cosmoz-resizable-view
+				style="display:flex; width:600px; height:300px;"
+				min-size="200"
+			>
+				<div id="prev" slot="previous">prev</div>
+				<div id="next" slot="next">next</div>
+			</cosmoz-resizable-view>`,
+		);
+		await waitUntil(
+			() => el.shadowRoot.querySelector('cosmoz-resize-handle'),
+			undefined,
+			{ timeout: 3000 },
+		);
+		const prev = el.querySelector('#prev');
+		const next = el.querySelector('#next');
+		expect(getComputedStyle(prev).minWidth).to.equal('200px');
+		expect(getComputedStyle(next).minWidth).to.equal('0px');
+	});
+
+	it('min-size-vertical overrides in vertical direction', async () => {
+		const el = await fixture(
+			html`<cosmoz-resizable-view
+				style="display:flex; width:600px; height:600px;"
+				direction="vertical"
+				min-size="200"
+				min-size-vertical="300"
+			>
+				<div id="prev" slot="previous">prev</div>
+				<div id="next" slot="next">next</div>
+			</cosmoz-resizable-view>`,
+		);
+		await waitUntil(
+			() => el.shadowRoot.querySelector('cosmoz-resize-handle'),
+			undefined,
+			{ timeout: 3000 },
+		);
+		const prev = el.querySelector('#prev');
+		expect(getComputedStyle(prev).minHeight).to.equal('300px');
+	});
+
+	it('unitless min-size values get px appended', async () => {
+		const el = await fixture(
+			html`<cosmoz-resizable-view
+				style="display:flex; width:600px; height:300px;"
+				min-size="200"
+			>
+				<div id="prev" slot="previous">prev</div>
+				<div id="next" slot="next">next</div>
+			</cosmoz-resizable-view>`,
+		);
+		await waitUntil(
+			() => el.shadowRoot.querySelector('cosmoz-resize-handle'),
+			undefined,
+			{ timeout: 3000 },
+		);
+		const prev = el.querySelector('#prev');
+		expect(getComputedStyle(prev).minWidth).to.equal('200px');
 	});
 });

--- a/test/resizers.test.js
+++ b/test/resizers.test.js
@@ -31,9 +31,7 @@ const setupPrevious = (style = {}) => {
 	Object.defineProperty(window, 'getComputedStyle', {
 		value: () => ({
 			minWidth: style.minWidth ?? '0px',
-			maxWidth: style.maxWidth ?? 'none',
 			minHeight: style.minHeight ?? '0px',
-			maxHeight: style.maxHeight ?? 'none',
 		}),
 		configurable: true,
 	});
@@ -112,26 +110,6 @@ describe('createFlexResize', () => {
 		expect(onResize.firstCall()[0]).to.equal(100);
 	});
 
-	it('clamps to computed max-width (horizontal)', () => {
-		const container = setupContainer({
-			left: 0,
-			top: 0,
-			width: 1000,
-			height: 600,
-		});
-		const previous = setupPrevious({ maxWidth: '800px' });
-		const handler = createFlexResize({
-			container,
-			previous,
-			direction: 'horizontal',
-			onResize,
-		});
-
-		handler(makeEvent('start', 900, 0));
-		handler(makeEvent('move', 900, 0));
-		expect(onResize.firstCall()[0]).to.equal(800);
-	});
-
 	it('clamps to computed min-height (vertical)', () => {
 		const container = setupContainer({
 			left: 0,
@@ -152,27 +130,7 @@ describe('createFlexResize', () => {
 		expect(onResize.firstCall()[0]).to.equal(200);
 	});
 
-	it('clamps to computed max-height (vertical)', () => {
-		const container = setupContainer({
-			left: 0,
-			top: 0,
-			width: 600,
-			height: 1000,
-		});
-		const previous = setupPrevious({ maxHeight: '600px' });
-		const handler = createFlexResize({
-			container,
-			previous,
-			direction: 'vertical',
-			onResize,
-		});
-
-		handler(makeEvent('start', 0, 900));
-		handler(makeEvent('move', 0, 900));
-		expect(onResize.firstCall()[0]).to.equal(600);
-	});
-
-	it('on end: calls onResizeEnd with px', () => {
+	it('on end: calls onResizeEnd', () => {
 		const container = setupContainer({
 			left: 0,
 			top: 0,
@@ -189,7 +147,7 @@ describe('createFlexResize', () => {
 
 		handler(makeEvent('start', 500, 0));
 		handler(makeEvent('end', 300, 0));
-		expect(onResizeEnd.firstCall()[0]).to.equal(300);
+		expect(onResizeEnd.callCount()).to.equal(1);
 	});
 
 	it('vertical direction uses y axis', () => {


### PR DESCRIPTION
## Summary

Declarative attribute API for panel sizing, replacing the need for consumers to set CSS custom properties directly.

## Changes

### Attribute-driven sizing
- `initial-size` / `min-size` attributes (+ `-horizontal` / `-vertical` variants) on `<cosmoz-resizable-view>`
- Unitless values auto-appended with `px` (e.g. `min-size="200"` → `200px`); values with units or CSS functions pass through unchanged
- Single-value `min-size="200"` applies to previous only; two values `min-size="200 100"` for previous + next
- Comma-separated values supported for `calc()` compatibility: `min-size="calc(100% - 200px), 300px"`
- Attributes parsed to `--resizable-*` CSS custom properties on host; static shadow DOM CSS maps them to physical properties via `:host([data-direction])` selectors with three-tier fallback

### Direction-aware persistence
- Persist key prefixed with direction: `${persist}:${direction}` — separate stored size per direction
- Persist stores actual rendered size via rAF + `getBoundingClientRect()` instead of mouse position (avoids storing values that exceed effective max)
- Stale inline `flexBasis` cleared on direction change when no stored value for the new direction — CSS default (`initial-size`) takes over

### Visibility fix
- `isVisible` checks `getComputedStyle(el).display !== 'none'` instead of bounding rect size
- Prevents `data-single-panel` oscillation: the `data-single-panel` CSS changes flex sizing which caused ResizeObserver feedback loop with size-based visibility

### Simplifications
- `readBounds` simplified to min-only (flexbox enforces effective max via other panel's min; no `max-size` attribute needed)
- `onResizeEnd` no longer receives `px` param (reads actual size from DOM via rAF)
- `snap` variable renamed to `_snapshot` for clarity

## Consumer migration

Before:
```html
<cosmoz-resizable-view persist="my-split">
  <div slot="previous" style="flex-basis: 60%; min-width: 220px">prev</div>
  <div slot="next">next</div>
</cosmoz-resizable-view>
```

After:
```html
<cosmoz-resizable-view
  persist="my-split"
  initial-size="60%"
  min-size="220"
>
  <div slot="previous">prev</div>
  <div slot="next">next</div>
</cosmoz-resizable-view>
```

## Test plan
- [x] 48 web-test-runner tests pass
- [x] Lint clean (tsc + eslint)
- [x] New `parse-size.test.js` unit tests for parsing
- [x] New tests for attribute sizing, direction-aware persist, stale flexBasis clearing