### PR TITLE
feat: redirect unslotted children to previous slot

### DIFF
--- a/.changeset/feat-default-slot-redirect.md
+++ b/.changeset/feat-default-slot-redirect.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-resizable': minor
+---
+
+Add default (unnamed) slot that redirects unslotted children to `previous` slot — safety net for callers that forget `slot="previous"`.

--- a/src/resizable-view.ts
+++ b/src/resizable-view.ts
@@ -98,6 +98,7 @@ const ResizableView = ({
 	const handleRef = useRef<HTMLElement>();
 	const prevSlotRef = useRef<HTMLSlotElement>();
 	const nextSlotRef = useRef<HTMLSlotElement>();
+	const defaultSlotRef = useRef<HTMLSlotElement>();
 	const [panelsReady, setPanelsReady] = useState(false);
 
 	const persistKey = persist ? `${persist}:${direction}` : undefined;
@@ -124,6 +125,12 @@ const ResizableView = ({
 		const prev = prevSlotRef.current?.assignedElements()[0];
 		const next = nextSlotRef.current?.assignedElements()[0];
 		if (prev && next) setPanelsReady(true);
+	}, []);
+
+	const onDefaultSlotChange = useCallback(() => {
+		defaultSlotRef.current
+			?.assignedElements()
+			.forEach((el) => el.setAttribute('slot', 'previous'));
 	}, []);
 
 	useEffect(() => {
@@ -184,6 +191,10 @@ const ResizableView = ({
 	}, [direction, adapter, persist, host, panelsReady]);
 
 	return html`<slot
+			${ref(defaultSlotRef)}
+			@slotchange=${onDefaultSlotChange}
+		></slot
+		><slot
 			name="previous"
 			${ref(prevSlotRef)}
 			@slotchange=${onSlotChange}

--- a/test/resizable-view.test.js
+++ b/test/resizable-view.test.js
@@ -49,11 +49,11 @@ describe('cosmoz-resizable-view', () => {
 		expect(nextSlot.assignedElements()[0]?.id).to.equal('next');
 	});
 
-	it('does not auto-assign unslotted children', async () => {
+	it('redirects unslotted children to previous slot', async () => {
 		const el = await fixture(
 			html`<cosmoz-resizable-view>
 				<div id="prev">prev</div>
-				<div id="next">next</div>
+				<div id="next" slot="next">next</div>
 			</cosmoz-resizable-view>`,
 		);
 		await waitUntil(
@@ -63,8 +63,11 @@ describe('cosmoz-resizable-view', () => {
 		);
 		const prevSlot = el.shadowRoot.querySelector('slot[name="previous"]');
 		const nextSlot = el.shadowRoot.querySelector('slot[name="next"]');
-		expect(prevSlot.assignedElements().length).to.equal(0);
-		expect(nextSlot.assignedElements().length).to.equal(0);
+		await waitUntil(() => prevSlot.assignedElements().length > 0, undefined, {
+			timeout: 3000,
+		});
+		expect(prevSlot.assignedElements()[0]?.id).to.equal('prev');
+		expect(nextSlot.assignedElements()[0]?.id).to.equal('next');
 	});
 
 	it('sets data-single-panel when one panel is display:none', async () => {


### PR DESCRIPTION
Add a default (unnamed) slot that catches elements without a `slot` attribute and redirects them to `slot="previous"`. Safety net for callers that forget `slot="previous"`.

Changes:
- `resizable-view.ts`: add unnamed `<slot>` before `previous` slot with a `slotchange` handler that sets `slot="previous"` on each assigned element
- `resizable-view.test.js`: update "does not auto-assign" test to verify redirect behavior
- 48 tests pass