### PR TITLE
fix: preserve calc() values with spaces in parseSizeAttr

### DIFF
--- a/.changeset/soft-numbers-spend.md
+++ b/.changeset/soft-numbers-spend.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-resizable': patch
+---
+
+Fix parseSizeAttr to preserve `calc()` and `var()` values containing spaces when splitting on whitespace. Previously `initial-size="calc(100% - 240px)"` would be mangled into separate tokens.

--- a/src/parse-size.ts
+++ b/src/parse-size.ts
@@ -9,7 +9,9 @@ export const parseSizeAttr = (
 	raw: string | null,
 ): { previous?: string; next?: string } => {
 	if (raw == null || raw.trim() === '') return {};
-	const parts = raw.includes(',') ? raw.split(/,\s*/u) : raw.split(/\s+/u);
+	const parts = raw.includes(',')
+		? raw.split(/,\s*/u)
+		: (raw.match(/(?:[^\s()]+\([^)]*\)|\([^)]*\)|[^\s]+)/gu) ?? [raw]);
 	return {
 		previous: addUnit(parts[0]),
 		next: parts.length > 1 ? addUnit(parts[1]) : undefined,

--- a/test/parse-size.test.js
+++ b/test/parse-size.test.js
@@ -55,4 +55,32 @@ describe('parseSizeAttr', () => {
 	it('returns empty for whitespace-only string', () => {
 		expect(parseSizeAttr('   ')).to.deep.equal({});
 	});
+
+	it('preserves calc() with internal spaces (whitespace-separated)', () => {
+		expect(parseSizeAttr('calc(100% - 240px)')).to.deep.equal({
+			previous: 'calc(100% - 240px)',
+			next: undefined,
+		});
+	});
+
+	it('preserves calc() with number as previous (whitespace-separated)', () => {
+		expect(parseSizeAttr('0 calc(100% - 200px)')).to.deep.equal({
+			previous: '0px',
+			next: 'calc(100% - 200px)',
+		});
+	});
+
+	it('preserves two calc() values (whitespace-separated)', () => {
+		expect(parseSizeAttr('calc(50% - 100px) calc(25% + 50px)')).to.deep.equal({
+			previous: 'calc(50% - 100px)',
+			next: 'calc(25% + 50px)',
+		});
+	});
+
+	it('preserves var() values (whitespace-separated)', () => {
+		expect(parseSizeAttr('var(--my-var) 200px')).to.deep.equal({
+			previous: 'var(--my-var)',
+			next: '200px',
+		});
+	});
 });


### PR DESCRIPTION
## Problem

`parseSizeAttr` splits attribute values on whitespace, which destroys `calc()` expressions containing spaces. For example:

`initial-size="calc(100% - 240px)"` was parsed as `['calc(100%', '-', '240px)']` instead of `['calc(100% - 240px)']`.

This resulted in `--resizable-previous-basis: calc();-;` being set as a CSS variable.

## Fix

Replace `raw.split(/\s+/u)` with a regex that treats parenthesized groups (`calc()`, `var()`) as single tokens while still splitting simple values on whitespace:

```js
raw.match(/(?:[^\s()]+\([^)]*\)|\([^)]*\)|[^\s]+)/gu)
```

## Tests

- `calc(100% - 240px)` → single token ✅
- `0 calc(100% - 200px)` → two tokens ✅  
- `calc(50% - 100px) calc(25% + 50px)` → two tokens ✅
- `var(--my-var) 200px` → two tokens ✅
- All existing tests still pass (52/52)